### PR TITLE
The config popup isn't annoying anymore and it has added functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,13 @@ Initial release of ...
 </ul>
 
 ## Extension Settings
-Make sure to include a configuration file named `surfql.json`
+Make sure to include a configuration file named `surfql.config.json`
+#### Example
+```json
+{
+  "schema": "./<path>.<graphql/graphqls/js>"
+}
+```
 
 
 <!-- ROADMAP -->

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "Other"
   ],
   "activationEvents": [
-    "workspaceContains:**/surfql.json",
+    "workspaceContains:**/surfql.config.json",
     "onCommand:surfql.previewSchema"
   ],
   "main": "./dist/extension.js",
@@ -25,6 +25,16 @@
         "title": "Preview Schema"
       }
     ],
+    "configuration": {
+      "title": "SurfQL",
+      "properties": {
+        "surfql.displayConfigPopup": {
+          "type": "boolean",
+          "default": true,
+          "description": "Displays a popup to automatically generate a config file."
+        }
+      }
+    },
     "viewsContainers": {
       "activitybar": [
         {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "Other"
   ],
   "activationEvents": [
-    "*",
+    "workspaceContains:**/surfql.json",
     "onCommand:surfql.previewSchema"
   ],
   "main": "./dist/extension.js",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -22,6 +22,7 @@ let disposable: vscode.Disposable;
 
 // This function will only be executed when the extension is activated.
 export async function activate(context: vscode.ExtensionContext) {
+	displayConfigPrompt();
 	// At startup
   console.log('SurfQL is now active 🌊');
 	[ queryEntry, schema, schemaPaths, enumArr ] = await configToSchema(); // Parse schema files from the config file
@@ -250,7 +251,7 @@ async function configToSchema(): Promise<[any, any, string[], Array<any>]> {
 	const filepath: string | undefined = await vscode.workspace.findFiles('**/surfql.json', '**/node_modules/**', 1).then(([ uri ]: vscode.Uri[]) => {
 		// When no file was found:
 		if (!uri) {
-			createSchemaPrompt(); // Prompt the user
+			displayConfigPrompt(); // Prompt the user
 			return; // Return undefined
 		}
 		// When a config file was found return the file path.
@@ -278,8 +279,20 @@ async function configToSchema(): Promise<[any, any, string[], Array<any>]> {
 	return [queryEntry, schemaObject, [schemaPath], enumArr];
 }
 
-function createSchemaPrompt(): void {
-	vscode.window.showInformationMessage("No surfql.json found");
+function displayConfigPrompt(): void {
+	vscode.window.showInformationMessage("No SurfQL config found. Would you like to generate one for this workspace?", 'Generate', 'Okay', 'Don\'t show again').then((userChoice) => {
+		if (userChoice === undefined) {
+			console.log('Create schema prompt dismissed');
+			return;
+		} else {
+			console.log({userChoice});
+			if (userChoice === 'Generate') {
+				console.log('Generating a config file...');
+			} else if (userChoice === 'Don\'t show again') {
+				console.log('Disabling this popup');
+			}
+		}
+	});
 	// TODO: Add a message with an "Okay" button that will auto-generate a config
 	//       file for the user (if they press "Okay").
 	// TODO: The file created will be loaded with { "schema": "./your-file-here/graphql" }


### PR DESCRIPTION
# Overview
The popup: "No surfql.json found" would pop up on every directory change within VSCode. This feature branch adjusts the extension's entry points to only load SurfQL when either are true:
- A surfql.config.json is present in the current workspace
- The previewSchema command was ran ("View Schema" button was clicked in the side bar)

⚠️ The config file is now named **surfql.config.json** and updates have been made accordingly.

## Popup New Features
- "Generate" option to automatically generate a surfql.config.json file with a basic template. This file is then opened for the user to adjust as needed.
- "Okay" option does nothing other than close the popup.
- "Don't show again" option updates the global extension settings to disable this popup from rendering in any workspace.