### PR TITLE
Supports: Query Comments (#) and JSX/TSX/TS File Types

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,14 +43,14 @@ Referencing
   </li>
 </ul>
 
-## Supports
-#### Parsing GraphQL Type Schemas:
-- File types: [".graphql", ".graphqls", ".ts", ".js"]
-- If your file containing the types is not listed, please open up an [issue](https://github.com/oslabs-beta/SurfQL/issues)
+## Supported File Types
+### GraphQL Schema Definition Files
+- Supported file types: `.graphql`, `.graphqls`, `.ts`, `.js`
+- To request support for additional file types, please create an [issue](https://github.com/oslabs-beta/SurfQL/issues)
 
-#### Autocomplete Suggestions:
-- File types: [".js", ".jsx", ".ts", ".tsx"]
-- If your file constructing the query is not listed, please open up an [issue](https://github.com/oslabs-beta/SurfQL/issues)
+### Autocomplete Suggestions
+- Supported file types: `.js`, `.jsx`, `.ts`, `.tsx`
+- To request support for additional file types, please create an [issue](https://github.com/oslabs-beta/SurfQL/issues)
 
 ## Extension Settings
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,15 @@ Referencing
   </li>
 </ul>
 
+## Supports
+#### Parsing GraphQL Type Schemas:
+- File types: [".graphql", ".graphqls", ".ts", ".js"]
+- If your file containing the types is not listed, please open up an [issue](https://github.com/oslabs-beta/SurfQL/issues)
+
+#### Autocomplete Suggestions:
+- File types: [".js", ".jsx", ".ts", ".tsx"]
+- If your file constructing the query is not listed, please open up an [issue](https://github.com/oslabs-beta/SurfQL/issues)
+
 ## Extension Settings
 
 Make sure to include a configuration file named `surfql.config.json`

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -8,7 +8,9 @@ export const primatives = [
 export const supportedSchemaParserFileTypes = ["graphql", "graphqls", "ts", "js"];
 
 //! When adding new language support:
-// - Add a new comment pattern for the respective language ids in `./lib/suggestions` -> `findBackTick()`
+// - Update `./lib/suggestions` -> `parseDocumentQuery()`
+//   to look for the associated language id's multi-line
+//   string character(s) and comment characters.
 export const supportedSuggestionFileTypeIds = ['javascript', 'typescript', 'javascriptreact', 'typescriptreact'];
 
 /* 🌊 Terms 🧠 */

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,6 +5,12 @@ export const primatives = [
   'ID'
 ];
 
+export const supportedSchemaParserFileTypes = ["graphql", "graphqls", "ts", "js"];
+
+//! When adding new language support:
+// - Add a new comment pattern for the respective language ids in `./lib/suggestions` -> `findBackTick()`
+export const supportedSuggestionFileTypeIds = ['javascript', 'typescript', 'javascriptreact', 'typescriptreact'];
+
 /* 🌊 Terms 🧠 */
 // Query Operations - "query" or "mutation" keywords at the start of a query.
 // Query Field - The term for the property/key on the query. Ex: "name" or "id"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -177,7 +177,7 @@ export async function activate(context: vscode.ExtensionContext) {
 		// console.log('Original history array:', messyHistoryArray);
 		// Stimulate spacing around brackets/parentheses for easier parsing.
 		const formattedHistoryArray: string[] = fixBadHistoryFormatting(messyHistoryArray);
-		// console.log('Formatted history array:', formattedHistoryArray);
+		console.log('Formatted history array:', formattedHistoryArray);
 		// Parse history array into an object.
 		const historyObject = historyToObject(formattedHistoryArray);
 		// console.log('COMPLETE SCHEMA:', historyObject);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,6 +15,7 @@ import {
 } from "./lib/suggestions";
 import { configToSchema, generateConfigFile } from './lib/config';
 import { Schema, QueryEntry } from './lib/models';
+import { supportedSuggestionFileTypeIds, supportedSchemaParserFileTypes } from './constants';
 
 let schema: Schema;
 let queryEntry: QueryEntry;
@@ -54,7 +55,7 @@ export async function activate(context: vscode.ExtensionContext) {
 					canSelectMany: false,
 					openLabel: "Open",
 					filters: {
-						"graphqlsFiles": ["graphql", "graphqls", "ts", "js"],
+						"graphqlsFiles": supportedSchemaParserFileTypes,
 					},
 				};
 
@@ -128,7 +129,7 @@ export async function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(previewSchemaCommand, configCommand);
 
 	const hoverProvider: vscode.Disposable = vscode.languages.registerHoverProvider(
-		'javascript', 
+		supportedSuggestionFileTypeIds, 
 		{
       provideHover(document, position, token) {
 				const range = document.getWordRangeAtPosition(position);
@@ -189,7 +190,7 @@ export async function activate(context: vscode.ExtensionContext) {
 		
 		// Create the CompletionItems.
 		disposable = vscode.languages.registerCompletionItemProvider(
-			['javascript', 'typescript', 'javascriptreact', 'typescriptreact'],
+			supportedSuggestionFileTypeIds,
 			{
 				provideCompletionItems() {		
 					return offerSuggestions(suggestions, currLine) as vscode.CompletionItem[];

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -210,6 +210,8 @@ export async function activate(context: vscode.ExtensionContext) {
 		}
 
 		// TODO:
+		//! Depending on the file type, ignore comments (prevent them from breaking document-query-parsing).
+		//! Open up the apollo-playground repo when debugging the extension.
 		// - Add cursor detection within args to auto suggest args instead of fields
 		// - Create TypeScript types for all these functions
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -184,7 +184,7 @@ export async function activate(context: vscode.ExtensionContext) {
 		// console.log('Original history array:', messyHistoryArray);
 		// Stimulate spacing around brackets/parentheses for easier parsing.
 		const formattedHistoryArray: string[] = fixBadHistoryFormatting(messyHistoryArray);
-		console.log('Formatted history array:', formattedHistoryArray);
+		// console.log('Formatted history array:', formattedHistoryArray);
 		// Parse history array into an object.
 		const historyObject = historyToObject(formattedHistoryArray);
 		// console.log('COMPLETE SCHEMA:', historyObject);
@@ -218,6 +218,7 @@ export async function activate(context: vscode.ExtensionContext) {
 		}
 
 		// TODO:
+		// - Clean up this file (move functions to separate files)!
 		// - Establish a linter (air bnb?)
 		// - Add cursor detection within args to auto suggest args instead of fields
 		// - Create TypeScript types for all these functions

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -189,7 +189,7 @@ export async function activate(context: vscode.ExtensionContext) {
 		
 		// Create the CompletionItems.
 		disposable = vscode.languages.registerCompletionItemProvider(
-			'javascript',
+			['javascript', 'typescript', 'javascriptreact', 'typescriptreact'],
 			{
 				provideCompletionItems() {		
 					return offerSuggestions(suggestions, currLine) as vscode.CompletionItem[];
@@ -211,7 +211,6 @@ export async function activate(context: vscode.ExtensionContext) {
 
 		// TODO:
 		//! Depending on the file type, ignore comments (prevent them from breaking document-query-parsing).
-		//! Open up the apollo-playground repo when debugging the extension.
 		// - Add cursor detection within args to auto suggest args instead of fields
 		// - Create TypeScript types for all these functions
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -218,7 +218,7 @@ export async function activate(context: vscode.ExtensionContext) {
 		}
 
 		// TODO:
-		//! Depending on the file type, ignore comments (prevent them from breaking document-query-parsing).
+		// - Establish a linter (air bnb?)
 		// - Add cursor detection within args to auto suggest args instead of fields
 		// - Create TypeScript types for all these functions
 

--- a/src/lib/suggestions.ts
+++ b/src/lib/suggestions.ts
@@ -416,26 +416,12 @@ function findBackTick(history: string[], direction: 1 | -1, limit: number, docum
         }
     };
 
-    
-    // TODO: Add further language support for comments (php, python, etc...)
-    let insideMultiLineComment: boolean = false;
-    const singleLineCommentsRegex: RegExp = /^\s*(\/\/.*)\s*$/; // Example: const fruit = banana; // Set the fruit to be a banana
-    const partialLineCommentsRegex: RegExp = /^.*(\/\*.*\*\/).*$/; // Example: const fruit = /* name of fruit: */ banana;
-    const startMultiLineCommentsRegex = (reverse: boolean): RegExp => reverse
-        ? /^.*(\*\/.*).*$/
-        : /^.*(\/\*.*).*$/; // Example: const fruit = banana; \/* Start of multi-line comment
+    const commentRegex: RegExp = /^\s*(\/\/.*)\s*$/; // Example: query { # This query will return all the users
     // Helper function to remove commented code.
     const removeComments = () => {
-        if (singleLineCommentsRegex.test(line)) { // Single-line comment
+        if (commentRegex.test(line)) {
             // Ignore the comment portion of the line.
-            line = line.slice(0, line.indexOf('//'));
-        } else if (partialLineCommentsRegex.test(line)) { // Partial-line comment
-            // Ignore the comment portion of the line.
-            line = line.slice(0, line.indexOf('/*'))
-                + line.slice(line.indexOf('*/') + 2);
-        } else if (startMultiLineCommentsRegex(reverse).test(line)) { // Start of multi-line comment (with no end)
-            insideMultiLineComment = true;
-            line = line.slice(0, line.indexOf('/*'));
+            line = line.slice(0, line.indexOf('#') - 1);
         }
     };
     
@@ -459,19 +445,6 @@ function findBackTick(history: string[], direction: 1 | -1, limit: number, docum
         if (line.length > limit) {
             console.log('Line has over', limit, 'characters. Limit reached for parsing.');
             return [];
-        }
-
-        // While we are within a multi-line comment, ignore everything until the end of the comment is reached.
-        if (insideMultiLineComment) {
-            // Check to see if the multi-line comment has ended.
-            if ((reverse && /\/\*/.test(line)) || (!reverse && /\*\//.test(line))) {
-                insideMultiLineComment = false;
-                // Ignore everything before the end of the comment then proceed to parse the rest (if any).
-                line = line.slice(line.indexOf('*/') + 2);
-            } else { // Still inside the comment
-                updateLine();
-                continue; // Continue to the next line
-            }
         }
 
         // Remove commented code.

--- a/src/lib/suggestions.ts
+++ b/src/lib/suggestions.ts
@@ -398,12 +398,14 @@ function findBackTick(history: string[], direction: 1 | -1, limit: number, docum
     // - Ignore everything before/after the cursor
     line = (direction === -1) ? line.slice(0, cursorLocation + 1) : line.slice(cursorLocation + 1);
     
-    // Create an array of words (and occasional characters such as: '{')
+    // Ignore the line if it's within a multi-line comment.
+    let insideComment = false;
+    // Create an array of words / characters found in queries.
     // Iterate through the lines of the file (starting from the cursor moving up the file)
     while (lineNumber >= 0 && newHistory.length <= limit) {
         // When the start of the query was found: This is the last loop
         if (line.includes('`')) {
-            lineNumber = -2; // Set line number to -2 to end the loop (-1 doesn't work)
+            lineNumber = -2; // Set line number to -2 to end the loop (-1 doesn't work and we still want to continue the rest of this logic)
             // Slice at the backtick
             const backTickIndex = line.indexOf('`');
             // The slice will depend on the 'direction' parameter.

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -325,6 +325,5 @@ export default function parser(text: string) {
     };
   });
 
-  console.log(root, queryMutation, enumArr, inputArr, scalarArr, unionArr);
   return [root, queryMutation, enumArr, inputArr, scalarArr, unionArr];
 };

--- a/stylesheet/preview.css
+++ b/stylesheet/preview.css
@@ -79,6 +79,31 @@ a {
     color: #5fefd0;
   }
 }
+/* TODO: Replace the above code with this .svg technique */
+/* .btn-selected::before {
+  content: url('path/to/file.svg');
+  display: inline-block;
+  width: 16px; adjust to match the size of your SVG
+  height: 16px; adjust to match the size of your SVG
+  margin-right: 5px; optional, adjust as needed
+  fill: currentColor; sets the fill color of the SVG to match the text color
+  animation-name: color-change;
+  animation-duration: 2s;
+  animation-iteration-count: infinite;
+  animation-direction: alternate;
+} */
+
+@keyframes color-change {
+  0% {
+    color: #5fefd0;
+  }
+  50% {
+    color: #282828;
+  }
+  100% {
+    color: #5fefd0;
+  }
+}
 
 .typedField {
   color: rgb(144, 151, 142) !important;


### PR DESCRIPTION
## New Features
- Comments (`#`) no longer break the autocomplete parser
- Autocomplete parser now supports more than `.js` files: `.jsx`, `.ts`, `.tsx`
- Notification at the bottom of the window whenever the schema is (re)loaded

## Updates
- README

## Potential Next Steps:
- Clean up the `extension.ts` file
- Establish a linter (air bnb?) for:
  - indentation cleanup mostly
  - overall consistencies